### PR TITLE
Fix bug: two similar routes with different auth requirements favors the public route

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -84,8 +84,7 @@ var router = function (app, _config) {
     };
   }
 
-  const publicRouter = new route();
-  const secureRouter = new route();
+  const router = new route();
 
   //Method in local parser has been move to fleek-parser
   _.each(swagger.sanitizedRoutes, function (routeObj) {
@@ -181,9 +180,9 @@ var router = function (app, _config) {
 
     var path = helpers.joinPaths(prefix, routeObj.path);
     if (routeObj.authRequired) {
-      secureRouter[routeObj.method](path, bindRouteData, response, authenticate, validate, middleware, methodHandler);
+      router[routeObj.method](path, bindRouteData, response, authenticate, validate, middleware, methodHandler);
     } else {
-      publicRouter[routeObj.method](path, bindRouteData, response, validate, middleware, methodHandler);
+      router[routeObj.method](path, bindRouteData, response, validate, middleware, methodHandler);
     }
   });
 
@@ -194,8 +193,7 @@ var router = function (app, _config) {
     app.use(documentation.koa(config.documentation));
   }
 
-  app.use(publicRouter.middleware());
-  app.use(secureRouter.middleware());
+  app.use(router.middleware());
 };
 
 module.exports = router;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleek-router",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A router for the fleek framework",
   "repository": "https://github.com/fleekjs/fleek-router",
   "main": "lib/router.js",


### PR DESCRIPTION
Example case:
Two similar routes eg:
`GET /users/list` - auth req
`GET /users/:id` - public
where the less specific route was public.

Problem:
The public routes are registered as middleware first, before the secured routes. So, in the above case, the more specific route does not take precedence.

Solution:
Register all routes together in one instance of koa-router.

@lan-nguyen91 